### PR TITLE
Fix dependency to chassis adapter lib

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ buildscript {
        classpath "io.spring.gradle:dependency-management-plugin:1.0.2.RELEASE"
        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.4.15"
        classpath 'com.github.jacobono:gradle-jaxb-plugin:1.3.6'
-       classpath "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.2.1"
+       classpath "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.6.1"
        classpath "gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:0.13.1"
        //classpath 'com.netflix.nebula:gradle-lint-plugin:latest.release'
   }
@@ -85,6 +85,7 @@ dependencies {
         compile 'com.dell.isg.smi:commons-elm:1.0.82'
         compile 'com.dell.isg.smi:commons-utilities:1.0.32'
         compile 'com.dell.isg.smi:wiseman:1.0.9'
+        compile 'com.dell.isg.smi:adapter-chassis:1.0.32'
         compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
         compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.6'
         compile group: 'commons-io', name: 'commons-io', version: '2.5'


### PR DESCRIPTION
## Background
The Gradle build failed to complete due to two reason:
1. sonarqube plugin is out of date.
2. This repo has multiple reference to the smi-lib-adapter-chassis. But this is not included in gradle file.

## Solution
1. Update sonarqube plugin to 2.6.1
2. Reference com.dell.isg.smi:adapter-chassis in gradle file.

@michaelsteven @phelpdh  @lanchongyizu 